### PR TITLE
Bincode codec without serde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-04-19
+
+### New Codecs
+
+- Add a `bincode` feature to encode with `bincode v2` without serde and native `bincode::Encode` and `bincode::Decode` derive macros (thanks to @zakstucke)
+
 ## [0.3.0] - 2025-01-09
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codee"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Marc-Stefan Cassola"]
 categories = ["encoding"]
@@ -13,7 +13,6 @@ repository = "https://github.com/Synphonyte/codee"
 
 [dependencies]
 base64 = { version = "0.22", optional = true }
-bincode = { version = "1", optional = true }
 js-sys = { version = "0.3", optional = true }
 miniserde = { version = "0.1", optional = true }
 prost = { version = "0.13", optional = true }
@@ -26,11 +25,18 @@ serde-wasm-bindgen = { version = "0.6", optional = true }
 thiserror = "2.0"
 wasm-bindgen = { version = "0.2", optional = true }
 
+# Optional bincode v1 for bincode_serde feature
+bincode_v1 = { package = "bincode", version = "1", optional = true }
+
+# Optional bincode v2 for bincode feature
+bincode = { package = "bincode", version = "2.0.1", optional = true }
+
 [features]
 prost = ["dep:prost"]
 json_serde = ["dep:serde_json", "dep:serde"]
 msgpack_serde = ["dep:rmp-serde", "dep:serde"]
-bincode_serde = ["dep:bincode", "dep:serde"]
+bincode = ["dep:bincode"]
+bincode_serde = ["dep:bincode_v1", "dep:serde"]
 serde_lite = ["dep:serde-lite"]
 json_serde_wasm = ["dep:serde", "dep:serde_json", "dep:js-sys", "dep:serde-wasm-bindgen", "dep:wasm-bindgen"]
 

--- a/src/binary/bincode.rs
+++ b/src/binary/bincode.rs
@@ -1,0 +1,52 @@
+/// A codec that relies on `bincode` to encode data.
+///
+/// This does not use serde but the bincode derive macros `bincode::Encode` and `bincode::Decode` instead.
+/// bincode recommends not using `serde` because of [known issues](https://docs.rs/bincode/latest/bincode/serde/index.html#known-issues).
+///
+/// This is only available with the **`bincode` feature** feature enabled.
+///
+/// If you want to use `serde` with bincode, please use the `bincode_serde` feature instead.
+pub struct BincodeCodec;
+
+impl<T: bincode::Encode> crate::Encoder<T> for BincodeCodec {
+    type Error = bincode::error::EncodeError;
+    type Encoded = Vec<u8>;
+
+    fn encode(val: &T) -> Result<Self::Encoded, Self::Error> {
+        bincode::encode_to_vec(val, bincode::config::standard())
+    }
+}
+
+impl<T: for<'a> bincode::de::BorrowDecode<'a, ()>> crate::Decoder<T> for BincodeCodec {
+    type Error = bincode::error::DecodeError;
+    type Encoded = [u8];
+
+    fn decode(val: &Self::Encoded) -> Result<T, Self::Error> {
+        let (data, _bytes_read) =
+            bincode::borrow_decode_from_slice(val, bincode::config::standard())?;
+        Ok(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Decoder, Encoder};
+
+    use super::*;
+
+    #[test]
+    fn test_bincode_codec() {
+        #[derive(Clone, Debug, PartialEq, bincode::Encode, bincode::Decode)]
+        struct Test {
+            s: String,
+            i: i32,
+        }
+        let t = Test {
+            s: String::from("party time 🎉"),
+            i: 42,
+        };
+        let enc = BincodeCodec::encode(&t).unwrap();
+        let dec: Test = BincodeCodec::decode(&enc).unwrap();
+        assert_eq!(dec, t);
+    }
+}

--- a/src/binary/bincode_serde.rs
+++ b/src/binary/bincode_serde.rs
@@ -1,6 +1,7 @@
 use crate::{Decoder, Encoder};
+use bincode_v1 as bincode;
 
-/// A codec that relies on `bincode` adn `serde` to encode data in the bincode format.
+/// A codec that relies on `bincode` and `serde` to encode data in the bincode format.
 ///
 /// This is only available with the **`bincode_serde` feature** enabled.
 pub struct BincodeSerdeCodec;

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "bincode")]
+mod bincode;
 #[cfg(feature = "bincode_serde")]
 mod bincode_serde;
 mod from_to_bytes;
@@ -8,6 +10,8 @@ mod prost;
 #[cfg(feature = "rkyv")]
 mod rkyv;
 
+#[cfg(feature = "bincode")]
+pub use bincode::*;
 #[cfg(feature = "bincode_serde")]
 pub use bincode_serde::*;
 #[allow(unused_imports)]


### PR DESCRIPTION
bincode v2 (https://docs.rs/bincode/latest/bincode/index.html) is out and provides a non-serde encoding pathway. We can add this as a non-breaking change as a `0.3.1`. 

I can add a separate PR after to bump the `bincode_serde` feature to v2, but this would require `0.4.0` and it'd be great to get the `bincode` feature in without a breaking change.