### PR TITLE
Implement `bitcode`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/Synphonyte/codee"
 
 [dependencies]
 base64 = { version = "0.22", optional = true }
+bitcode = { version = "0.6.6", optional = true }
 js-sys = { version = "0.3", optional = true }
 miniserde = { version = "0.1", optional = true }
 prost = { version = "0.14", optional = true }
@@ -38,6 +39,8 @@ json_serde = ["dep:serde_json", "dep:serde"]
 msgpack_serde = ["dep:rmp-serde", "dep:serde"]
 bincode = ["dep:bincode"]
 bincode_serde = ["dep:bincode_v1", "dep:serde"]
+bitcode = ["dep:bitcode"]
+bitcode_serde = ["dep:bitcode", "bitcode/serde", "dep:serde"]
 serde_lite = ["dep:serde-lite"]
 json_serde_wasm = [
     "dep:serde",

--- a/src/binary/bitcode.rs
+++ b/src/binary/bitcode.rs
@@ -1,0 +1,82 @@
+/// A codec that relies on `bitcode` to encode data.
+///
+/// This is only available with the **`bitcode` feature** feature enabled.
+///
+/// If you want to use `serde` with bitcode, please use the `bitcode_serde` feature instead.
+pub struct BitcodeCodec;
+
+impl<T: bitcode::Encode> crate::Encoder<T> for BitcodeCodec {
+    type Error = ();
+    type Encoded = Vec<u8>;
+
+    fn encode(val: &T) -> Result<Self::Encoded, Self::Error> {
+        Ok(bitcode::encode(val))
+    }
+}
+
+impl<T: for<'a> bitcode::Decode<'a>> crate::Decoder<T> for BitcodeCodec {
+    type Error = bitcode::Error;
+    type Encoded = [u8];
+
+    fn decode(val: &Self::Encoded) -> Result<T, Self::Error> {
+        bitcode::decode(val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Decoder, Encoder};
+
+    use super::*;
+
+    #[test]
+    fn test_bitcode_codec() {
+        #[derive(Clone, Debug, PartialEq, bitcode::Encode, bitcode::Decode)]
+        struct Test {
+            s: String,
+            i: i32,
+        }
+        let t = Test {
+            s: String::from("party time 🎉"),
+            i: 42,
+        };
+        let enc = BitcodeCodec::encode(&t).unwrap();
+        let dec: Test = BitcodeCodec::decode(&enc).unwrap();
+        assert_eq!(dec, t);
+    }
+
+    #[test]
+    fn test_bitcode_codec_complex() {
+        use std::collections::BTreeMap;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        #[derive(Debug, PartialEq, bitcode::Encode, bitcode::Decode)]
+        struct Test {
+            s: String,
+            i: i32,
+            m: HashMap<String, i32>,
+            b: BTreeMap<String, i32>,
+            a: Arc<String>,
+        }
+        let t = Test {
+            s: String::from("party time 🎉"),
+            i: 42,
+            m: HashMap::from([("a".to_string(), 1), ("b".to_string(), 2)]),
+            b: BTreeMap::from([("a".to_string(), 1), ("b".to_string(), 2)]),
+            a: Arc::new(String::from("party time 🎉"))
+        };
+        let enc = BitcodeCodec::encode(&t).unwrap();
+        let dec: Test = BitcodeCodec::decode(&enc).unwrap();
+        assert_eq!(dec, t);
+    }
+
+    #[test]
+    fn test_bitcode_codec_error() {
+        #[derive(bitcode::Encode, bitcode::Decode)]
+        struct Test;
+        let enc = [0];
+        let dec: Result<Test, bitcode::Error> = BitcodeCodec::decode(&enc);
+        assert!(dec.is_err());
+    }
+}

--- a/src/binary/bitcode_serde.rs
+++ b/src/binary/bitcode_serde.rs
@@ -1,0 +1,45 @@
+use crate::{Decoder, Encoder};
+
+/// A codec that relies on `bitcode` and `serde` to encode data in the bitcode format.
+///
+/// This is only available with the **`bitcode_serde` feature** enabled.
+pub struct BitcodeSerdeCodec;
+
+impl<T: serde::Serialize> Encoder<T> for BitcodeSerdeCodec {
+    type Error = bitcode::Error;
+    type Encoded = Vec<u8>;
+
+    fn encode(val: &T) -> Result<Self::Encoded, Self::Error> {
+        bitcode::serialize(val)
+    }
+}
+
+impl<T: serde::de::DeserializeOwned> Decoder<T> for BitcodeSerdeCodec {
+    type Error = bitcode::Error;
+    type Encoded = [u8];
+
+    fn decode(val: &Self::Encoded) -> Result<T, Self::Error> {
+        bitcode::deserialize(val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bitcode_codec() {
+        #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+        struct Test {
+            s: String,
+            i: i32,
+        }
+        let t = Test {
+            s: String::from("party time 🎉"),
+            i: 42,
+        };
+        let enc = BitcodeSerdeCodec::encode(&t).unwrap();
+        let dec: Test = BitcodeSerdeCodec::decode(&enc).unwrap();
+        assert_eq!(dec, t);
+    }
+}

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -2,6 +2,10 @@
 mod bincode;
 #[cfg(feature = "bincode_serde")]
 mod bincode_serde;
+#[cfg(feature = "bitcode")]
+mod bitcode;
+#[cfg(feature = "bitcode_serde")]
+mod bitcode_serde;
 mod from_to_bytes;
 #[cfg(feature = "msgpack_serde")]
 mod msgpack_serde;
@@ -14,6 +18,10 @@ mod rkyv;
 pub use bincode::*;
 #[cfg(feature = "bincode_serde")]
 pub use bincode_serde::*;
+#[cfg(feature = "bitcode")]
+pub use bitcode::*;
+#[cfg(feature = "bitcode_serde")]
+pub use bitcode_serde::*;
 #[allow(unused_imports)]
 pub use from_to_bytes::*;
 #[cfg(feature = "msgpack_serde")]


### PR DESCRIPTION
Although sounds very similar to `bincode`, `bitcode` has been on the top of [rust ser/de benchmarks](https://github.com/djkoloski/rust_serialization_benchmark)

I use this library both directly, and indirectly via `leptos`, and adding `bitcode` codecs would be great.

Thankfully, the way this project is structured required very minimal lift, works like a charm.